### PR TITLE
Modified the list of dependencies...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ dist
 cabal-dev
 *.o
 *.hi
+*.exe
 *.chi
 *.chs.h
 .virthualenv
+.cabal-sandbox/
+cabal.sandbox.config

--- a/roller.cabal
+++ b/roller.cabal
@@ -22,17 +22,17 @@ library
                        Roller.Types,
                        Roller.Parse,
                        Roller.CLI
-  build-depends:       base ==4.7.*,
+  build-depends:       base >=4.7,
                        random >=1.0.1,
-                       regex-applicative >=0.3 && <0.3.1,
-                       optparse-applicative >=0.11.0 && <0.11.1
+                       regex-applicative >=0.3,
+                       optparse-applicative >=0.11.0
   default-language:    Haskell2010
 
 executable roller
   main-is:             Roller.hs
-  build-depends:       base ==4.7.*,
+  build-depends:       base >=4.7,
                        random >=1.0.1,
-                       regex-applicative >=0.3 && <0.3.1,
-                       optparse-applicative >=0.11.0 && <0.11.1,
+                       regex-applicative >=0.3,
+                       optparse-applicative >=0.11.0,
                        roller
   default-language:    Haskell2010


### PR DESCRIPTION
Modified the list of dependencies to include the latest versions of [base](http://hackage.haskell.org/package/base-4.8.1.0) and [regex-applicative](http://hackage.haskell.org/package/regex-applicative-0.3.1).

Additionally, modified the gitignore file not to track changes in sandbox cabal environment and executables.